### PR TITLE
PAAS-551 fix escape doublequotes for settings paramater in cronjob

### DIFF
--- a/autobackup/app.py
+++ b/autobackup/app.py
@@ -53,7 +53,7 @@ class CronJob(Resource):
             command = script.format(login='${MASTER_LOGIN}',
                                     password='${MASTER_PWD}',
                                     url=args.url,
-                                    settings= args.settings.replace("'", '\\"'),
+                                    settings=args.settings.replace('"', '\\"'),
                                     env=args.envname,
                                     sudo=args.sudo)
         else:


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-551

Short description:
