### PR TITLE
PAAS-584: add missing globals for jcustomer backup when source_env ar…

### DIFF
--- a/restore.yml
+++ b/restore.yml
@@ -21,6 +21,9 @@ onInstall:
               - if(settings.uid_source):
                   - setGlobals:
                       bucketname: jc${settings.envrole_source}${settings.uid_source}${globals.wc_region_source} -F ${settings.cloud_source},${settings.region_source},${settings.envrole_source}
+              - setGlobals:
+                  regionRealName_source: ${settings.region_source}
+                  cloudProvider_source: ${settings.cloud_source}
 
   - if(settings.source_env):
       - envSource


### PR DESCRIPTION
…g is not defined

JIRA issue: https://jira.jahia.org/browse/PAAS-584

Short description:
add missing globals for jcustomer backup when source_env arg is not defined