### PR TITLE
PAAS-752: use an env var to define the backup manifest's version to use

### DIFF
--- a/autobackup/app.py
+++ b/autobackup/app.py
@@ -16,7 +16,7 @@ LOG_FORMAT = "%(levelname)s: [%(funcName)s] %(message)s"
 logging.basicConfig(format=LOG_FORMAT, level=logging.INFO)
 
 
-script = "source /.jelenv && export $(grep MASTER_PWD /.jelenv) && cd / && python3 /import_package_as_user.py -l \"{login}\" -p \"{password}\" -u '{url}' --settings \"{settings}\" --env {env} -s \"{sudo}\" >> /var/log/backup_{sudo}-{env}.log 2>&1"
+script = "source /.jelenv && export $(grep MASTER_PWD /.jelenv) && cd / && python3 /import_package_as_user.py -l \"{login}\" -p \"{password}\" -u "{url}" --settings \"{settings}\" --env {env} -s \"{sudo}\" >> /var/log/backup_{sudo}-{env}.log 2>&1"
 
 @app.route("/")
 def hello():

--- a/autobackup/auto_backup.yml
+++ b/autobackup/auto_backup.yml
@@ -42,6 +42,8 @@ onInstall:
   - cmd[cp]: |-
       sed 's/__ENV__/${globals.env}/' -i /etc/datadog-agent/datadog.yaml
       systemctl enable --now datadog-agent
+  - env.control.AddContainerEnvVars[cp]:
+    vars: {"BACKUP_BRANCH": "master"}
 
 
 settings:


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-752

Short description:
use an env var to define the backup manifest's version to use

The simple quotes around url parameter were breaking bash variable usage. I just changed it to double quotes