### PR TITLE
PAAS-752: use an env var to define the backup manifest's version to use

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,9 +2,10 @@
 
 ## actual version: v1.3
 
-### v1.4 (2020-02-11)
+### v1.4 (2020-02-18)
 * [NEW]: Do not try to backup stopped env
 * [NEW]: Use Pypi official package *jahia-pylastic* instead of a local Pypi version
+* [NEW]: Use an env var to define which backup package version to use in autobackups
 
 ### v1.3
 

--- a/autobackup/app.py
+++ b/autobackup/app.py
@@ -16,7 +16,7 @@ LOG_FORMAT = "%(levelname)s: [%(funcName)s] %(message)s"
 logging.basicConfig(format=LOG_FORMAT, level=logging.INFO)
 
 
-script = "source /.jelenv && export $(grep MASTER_PWD /.jelenv) && cd / && python3 /import_package_as_user.py -l \"{login}\" -p \"{password}\" -u '{url}' --settings \"{settings}\" --env {env} -s \"{sudo}\" >> /var/log/backup_{sudo}-{env}.log 2>&1"
+script = "source /.jelenv && export $(grep MASTER_PWD /.jelenv) && cd / && python3 /import_package_as_user.py -l \"{login}\" -p \"{password}\" -u \"{url}\" --settings \"{settings}\" --env {env} -s \"{sudo}\" >> /var/log/backup_{sudo}-{env}.log 2>&1"
 
 @app.route("/")
 def hello():
@@ -52,7 +52,7 @@ class CronJob(Resource):
         if not args.command:
             command = script.format(login='${MASTER_LOGIN}',
                                     password='${MASTER_PWD}',
-                                    url=args.url,
+                                    url="https://raw.githubusercontent.com/Jahia/paas_jelastic_backup/$BACKUP_BRANCH/backup.yml",
                                     settings=args.settings.replace('"', '\\"'),
                                     env=args.envname,
                                     sudo=args.sudo)

--- a/autobackup/auto_backup.yml
+++ b/autobackup/auto_backup.yml
@@ -42,6 +42,8 @@ onInstall:
   - cmd[cp]: |-
       sed 's/__ENV__/${globals.env}/' -i /etc/datadog-agent/datadog.yaml
       systemctl enable --now datadog-agent
+  - env.control.AddContainerEnvVars[cp]:
+    vars: {"BACKUP_BRANCH": "master"}
 
 
 settings:


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-752

Short description:
use an env var to define the backup manifest's version to use