### PR TITLE
PAAS-953: Fix marker file used for restore backup for Jahia 7.2.x

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -2,6 +2,11 @@
 
 ## actual version: v1.3
 
+### v1.4.2 (2020-04-29)
+* [BUG]: PAAS-953 fix marker file used for restore backup for Jahia under 7.2.3.2
+
+### v1.4.1
+
 ### v1.4 (2020-02-18)
 * [NEW]: Do not try to backup stopped env
 * [NEW]: Use Pypi official package *jahia-pylastic* instead of a local Pypi version

--- a/restore.yml
+++ b/restore.yml
@@ -79,7 +79,7 @@ actions:
         - chown tomcat:tomcat -R /opt/tomcat/conf
         - rm -f digital-factory-config.tar.gz
         - rm -f /data/digital-factory-data/repository/.lock
-        - touch /data/digital-factory-data/safe-env-clone
+        - if [ $(echo $DX_VERSION | sed 's/\.//g') -lt 7232 ]; then touch /data/digital-factory-data/backup-restore; else touch /data/digital-factory-data/safe-env-clone; fi;
         - sed -i "s|^cluster.node.serverId.*|cluster.node.serverId = $HOSTNAME|g" $STACK_PATH/conf/digital-factory-config/jahia/jahia.node.properties
     - if (settings.removeEnvlink && ${settings.removeEnvlink} == false):
         - log: keep env link


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-953

Short description:
 - For all 7.2 environments, use the backup-restore filename
 - For all 7.3 / 8 environments, use safe-env-clone filename