### PR TITLE
PAAS-1371: improve timeout for galera restart after restore

### DIFF
--- a/mixins/database.yml
+++ b/mixins/database.yml
@@ -80,13 +80,19 @@ actions:
           i=1
           it=300
           until [ "$(mysql -Ns -e "show global status like 'wsrep_local_state_comment'" | awk '{print $NF}')" == "Synced"  ]; do
-            echo "$(date) not ready yet (iteration $i/$it)"
             if [ $i -ge $it ]; then
               echo "Too long to start, something is wrong here... EXITING"
               exit 1
             fi
-            sleep 1
-            ((i++))
+            # As long as there is a rsync going, we don't increment the timeout count
+            if ps -e -o command | grep -Eq "^rsync .* rsync_sst\.conf$"; then
+              echo "$(date) SSTs sync still in progress"
+              sleep 15
+            else
+              echo "$(date) not ready yet (iteration $i/$it)"
+              ((i++))
+              sleep 1
+            fi
           done
           echo "Node $HOSTNAME is now Synced !"
         user: root


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-1371

Short description:
I changed the way to do for something cleaner in my opinion: as long as there are SSTs going, we don't need to increment the timeout as it is the normal restore process, rather than setting an arbitrary value (for example 900 instead of 300) and increasing it each time we will have an issue with bigger databases)