### PR TITLE
PAAS-1383: Remove unused 'env' and 'gitrepo' settings

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-*   @laurentfufu

--- a/backup.yml
+++ b/backup.yml
@@ -173,11 +173,6 @@ settings:
       caption: AWS Secret Key
       vtype: text
       required: true
-    - name: gitrepo
-    - name: env
-      type: string
-      required: true
-      default: prod
     - name: timestamp
       caption: timestamp in format %Y-%m-%dT%H:%M:00
       required: false

--- a/restore.yml
+++ b/restore.yml
@@ -328,10 +328,6 @@ settings:
       values:
         dev: dev
         prod: prod
-    - name: env
-      type: string
-      required: true
-      default: prod
     - name: timestamp
       caption: timestamp in format %Y-%m-%dT%H:%M:00
       required: true


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-1383

Please merge at same time as https://github.com/Jahia/jahia-cloud-modules/pull/277

From what I saw the "env" setting isn't used anywhere. Same thing for "gitrepo", so I removed it too.